### PR TITLE
Circle 2.0 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/wopinator
+    docker:
+      - image: kapost/ruby:2.4.3-node-6.11.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: Rspec
+          command: bundle exec rspec --color --format documentation --require spec_helper spec

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  ruby:
-    version: 2.3.1
-
-dependencies:
-  pre:
-    - gem install bundler -v 1.12.5


### PR DESCRIPTION
Circle is sunsetting 1.0 builds and configs effective August 31, 2018. This gets wopinator on Circle 2.0

